### PR TITLE
Allow building with 4.12-rc4

### DIFF
--- a/nuc_led.c
+++ b/nuc_led.c
@@ -36,7 +36,7 @@
 #include <linux/proc_fs.h>
 #include <linux/acpi.h>
 #include <linux/vmalloc.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 
 MODULE_AUTHOR("Miles Peterson");
 MODULE_DESCRIPTION("Intel NUC LED Control WMI Driver");


### PR DESCRIPTION
This PR applied on top of https://github.com/milesp20/intel_nuc_led/commit/fedb38e1d221098076f079f9bede5fce76fa5363 has been successfully build and run-time tested with kernels 4.11.3 and 4.12-rc4.

Without this PR, building with kernel 4.12-rc4 fails as follows:
```
make[1]: Entering directory '/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e'
make -C /home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/linux-4.12-rc4 M=/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e modules
make[2]: Entering directory '/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/linux-4.12-rc4'
  CC [M]  /home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.o
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c: In function 'acpi_proc_write':
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c:217:13: error: implicit declaration of function 'copy_from_user' [-Werror=implicit-function-declaration]
         if (copy_from_user(input, buff, len))
             ^~~~~~~~~~~~~~
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c:344:147: warning: 'retval.color_return' may be used uninitialized in this function [-Wmaybe-uninitialized]
                         else if (retval.brightness_return == NUCLED_WMI_RETURN_BADPARAM || retval.blink_fade_return == NUCLED_WMI_RETURN_BADPARAM ||
                                                                                                                                                   ^
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c:344:89: warning: 'retval.blink_fade_return' may be used uninitialized in this function [-Wmaybe-uninitialized]
                         else if (retval.brightness_return == NUCLED_WMI_RETURN_BADPARAM || retval.blink_fade_return == NUCLED_WMI_RETURN_BADPARAM ||
                                                                                         ^
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c:349:33: warning: 'retval.brightness_return' may be used uninitialized in this function [-Wmaybe-uninitialized]
                         else if (retval.brightness_return != NUCLED_WMI_RETURN_SUCCESS)
                                 ^
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c:167:35: warning: 'color_state' may be used uninitialized in this function [-Wmaybe-uninitialized]
         struct led_set_state_args args = {
                                   ^~~~
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c:210:42: note: 'color_state' was declared here
         u32 led, brightness, blink_fade, color_state;
                                          ^~~~~~~~~~~
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c:167:35: warning: 'blink_fade' may be used uninitialized in this function [-Wmaybe-uninitialized]
         struct led_set_state_args args = {
                                   ^~~~
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c:210:30: note: 'blink_fade' was declared here
         u32 led, brightness, blink_fade, color_state;
                              ^~~~~~~~~~
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c:167:35: warning: 'brightness' may be used uninitialized in this function [-Wmaybe-uninitialized]
         struct led_set_state_args args = {
                                   ^~~~
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c:210:18: note: 'brightness' was declared here
         u32 led, brightness, blink_fade, color_state;
                  ^~~~~~~~~~
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c:167:35: warning: 'led' may be used uninitialized in this function [-Wmaybe-uninitialized]
         struct led_set_state_args args = {
                                   ^~~~
/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.c:210:13: note: 'led' was declared here
         u32 led, brightness, blink_fade, color_state;
             ^~~
cc1: some warnings being treated as errors
make[3]: *** [scripts/Makefile.build:309: /home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e/nuc_led.o] Error 1
make[2]: *** [Makefile:1512: _module_/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e] Error 2
make[2]: Leaving directory '/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/linux-4.12-rc4'
make[1]: *** [Makefile:8: default] Error 2
make[1]: Leaving directory '/home/neil/projects/scratch/alternates/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel-next/intel_nuc_led-fedb38e'
Makefile:9: recipe for target 'release' failed
make: *** [release] Error 2
```