### PR TITLE
Travis CI support, .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.o
+*.ko
+*.order
+*.symvers
+*.cmd
+*.mod.c
+.tmp_versions/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+language: c
+compiler: gcc
+
+dist: trusty
+
+before_install:
+  - sudo apt-get update -q
+  - sudo apt-get install -y linux-headers-$(uname -r)
+
+script:
+  - make


### PR DESCRIPTION
- Adds a `.travis.yml` file which allows you to build the kernel module on Travis.
- Adds a `.gitignore` file for the build output, keeping git status clean.