### PR TITLE
fix build with kernel 5.6-rc1

### DIFF
--- a/nuc_led.c
+++ b/nuc_led.c
@@ -37,6 +37,7 @@
 #include <linux/acpi.h>
 #include <linux/vmalloc.h>
 #include <linux/uaccess.h>
+#include <linux/version.h>
 
 MODULE_AUTHOR("Miles Peterson");
 MODULE_DESCRIPTION("Intel NUC LED Control WMI Driver");
@@ -443,11 +444,18 @@ static ssize_t acpi_proc_read(struct file *filp, char __user *buff,
         return ret;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0))
+static struct proc_ops proc_acpi_operations = {
+        .proc_read     = acpi_proc_read,
+        .proc_write    = acpi_proc_write,
+};
+#else
 static struct file_operations proc_acpi_operations = {
         .owner    = THIS_MODULE,
         .read     = acpi_proc_read,
         .write    = acpi_proc_write,
 };
+#endif
 
 /* Init & unload */
 static int __init init_nuc_led(void)


### PR DESCRIPTION
Quick & dirty fix for 5.6-rc1. No problem if you'd rather fix this another way without the #ifdef.

Ref: https://github.com/torvalds/linux/commit/d56c0d45f0e27f814e87a1676b6bdccccbc252e9