### PR TITLE
Use proc_ops instead of file_operations on Linux >= 5.6

### DIFF
--- a/nuc_led.c
+++ b/nuc_led.c
@@ -30,6 +30,7 @@
 
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
+#include <linux/version.h>
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/types.h>
@@ -443,11 +444,18 @@ static ssize_t acpi_proc_read(struct file *filp, char __user *buff,
         return ret;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+static struct proc_ops proc_acpi_operations = {
+        .proc_read     = acpi_proc_read,
+        .proc_write    = acpi_proc_write,
+};
+#else
 static struct file_operations proc_acpi_operations = {
         .owner    = THIS_MODULE,
         .read     = acpi_proc_read,
         .write    = acpi_proc_write,
 };
+#endif
 
 /* Init & unload */
 static int __init init_nuc_led(void)


### PR DESCRIPTION
The proc_create API is changing in Linux 5.6, update code accordingly
See https://github.com/torvalds/linux/commit/d56c0d45f0e27f814e87a1676b6bdccccbc252e9